### PR TITLE
add org justfile

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,46 @@
+alias e := export
+alias r := refresh
+alias u := update
+
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
+default:
+    @just --list
+
+[private]
+[windows]
+_batchcmd cmd loader:
+    Get-ChildItem -Path versions\{{ if loader == "all" { "*\\*" } else { loader } }} -Directory | % { \
+      Set-Location $_.FullName; \
+      Write-Host "running {{ cmd }} in" versions\loader\$_; \
+      Invoke-Expression "{{ cmd }}"; \
+      Pop-Location; \
+    }
+
+[linux]
+[macos]
+[private]
+_batchcmd cmd loader:
+    for d in versions/{{ if loader == "all" { "*" } else { loader } }}/*/; do \
+      pushd "$d" &> /dev/null; \
+      echo "running {{ cmd }} in $d..."; \
+      {{ cmd }}; \
+      popd &> /dev/null; \
+    done
+
+# all versions of <loader> (or "all") will be exported as a modrinth modpack
+[linux]
+[macos]
+export loader: && (_batchcmd "packwiz modrinth export; mv *.mrpack ../../../build/" loader)
+    -mkdir -p build/
+
+# all versions of <loader> (or "all") will be exported as a modrinth modpack
+[windows]
+export loader: && (_batchcmd "packwiz modrinth export; Move-Item -Force -Path *.mrpack -Destination ../../../build/" loader)
+    -New-Item -Force -Type Directory -Path build/
+
+# all versions of <loader> (or "all") will have pack.toml & index.toml refreshed
+refresh loader: && (_batchcmd "packwiz refresh" loader)
+
+# all versions of <loader> (or "all") will be updated
+update loader: && (_batchcmd "packwiz update --all" loader)


### PR DESCRIPTION
currently, most repositories use a *very* similar (and complex) makefile, but with no clear guidance for newer modpacks. this pr introduces what can hopefully be a template justfile for all modpacks in this organization

## highlights

- truly crossplatform
  - `sh` is used on both macos and linux, while `pwsh` is used on windows (this is not the case with `make`)
  - this allows for maintenance scripts to be run regardless of a maintainer's os of choice
  - similar to `make`, `just` itself is available on any commonly used platform

- modular recipes
    - purposefully, no recipes are loader specific; this depends on repositories continuing to have a similar structure for multiple loaders, though
    - this makes the justfile much easier to extend in the future

- reduced dependencies
    - `pw` has been replaced with builtin shell functions

- reduced workload for maintainers 
    - ideally, changes made to the justfile here can benefit all repositories

## breaking changes

- packwiz is not managed
    - imo, packwiz should be installed by the user and assumed to be present by the justfile. using `go install` is not great in general and there are usually easier ways to install packwiz anyways

- `<function>-<loader>` commands are now `<function> <loader>`
    - i.e., `refresh-quilt` is now `refresh quilt`
    - this is due to the loader actually being an argument for a general `refresh` function

## how to use

when running `just`, a brief description will be displayed for each command. note that for each `loader`, you may also specify `all` to apply to all loaders (i.e., `just export all`)